### PR TITLE
Further test improvements

### DIFF
--- a/src/__tests__/AlbumForm.test.tsx
+++ b/src/__tests__/AlbumForm.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, cleanup } from "@testing-library/react";
 import { calculateNumberOfAlbums } from "../utils";
+import "@testing-library/jest-dom";
 import AlbumForm from "../components/AlbumForm";
 import { photos1, photos2 } from "../mockPhotoAPIData";
 
@@ -15,12 +16,12 @@ describe("AlbumForm component", () => {
   it("should render", () => {
     render(<AlbumForm photos={photos1} changeAlbumId={callback} />);
     const inputElement = screen.getByPlaceholderText("Enter album id");
-    expect(inputElement).toBeDefined;
+    expect(inputElement).toBeInTheDocument();
   });
   it("should have a label", () => {
     render(<AlbumForm photos={photos1} changeAlbumId={callback} />);
     const labelElement = screen.getByText("Search by album id");
-    expect(labelElement).toBeDefined;
+    expect(labelElement).toBeInTheDocument();
   });
   it("should have a label with the correct number of albums to pick from for 2 albums", () => {
     render(<AlbumForm photos={photos1} changeAlbumId={callback} />);
@@ -28,9 +29,8 @@ describe("AlbumForm component", () => {
     const labelElement = screen.getByText(
       new RegExp(`numbers 1-${numberOfAlbums}`) // <-------- From ChatGPT
     );
-    expect(labelElement).toBeDefined();
-    expect(labelElement.innerHTML).toBeDefined();
-    expect(labelElement.innerHTML).toContain("2");
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement).toHaveTextContent("2");
   });
   it("should have a label with the correct number of albums to pick from for 1 album", () => {
     render(<AlbumForm photos={photos2} changeAlbumId={callback} />);
@@ -38,16 +38,12 @@ describe("AlbumForm component", () => {
     const labelElement = screen.getByText(
       new RegExp(`numbers 1-${numberOfAlbums}`) // <-------- From ChatGPT
     );
-    expect(labelElement).toBeDefined();
-    expect(labelElement.innerHTML).toBeDefined();
-    expect(labelElement.innerHTML).toContain("3");
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement).toHaveTextContent("3");
   });
 });
 
 describe("calculateNumberOfAlbums", () => {
-  it("should be defined", () => {
-    expect(calculateNumberOfAlbums).toBeDefined();
-  });
   it("should return 2 when passed photos1", () => {
     expect(calculateNumberOfAlbums(photos1)).toEqual(2);
   });

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 import App from "../App";
 import { PhotoAPI } from "../PhotoAPI";
 import { photos1 } from "../mockPhotoAPIData";
@@ -24,14 +25,14 @@ describe("App component", () => {
     render(<App />);
     waitFor(() => {
       const h1Element = screen.getByRole("heading", { name: "Photo Showcase" });
-      expect(h1Element).toBeDefined();
+      expect(h1Element).toBeInTheDocument();
     });
   });
 
   it("should display a heading with album number 1", () => {
     render(<App />);
     const h2Element = screen.getByRole("heading", { name: "Album 1 Photos" });
-    expect(h2Element).toBeDefined;
+    expect(h2Element).toBeInTheDocument();
   });
 
   it("should allow the album id to change", async () => {
@@ -42,7 +43,7 @@ describe("App component", () => {
 
     await userEvent.type(albumIdInput, "2");
 
-    expect(albumIdInput).toBeDefined();
+    expect(albumIdInput).toBeInTheDocument();
     await waitFor(() => {
       expect(albumIdInput.value).toBe("2");
       const photosHeading = screen.getAllByRole("heading", { level: 2 })[0];

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -9,7 +9,6 @@ PhotoAPI.getAll = mockPhotoAPI.mockReturnValue(Promise.resolve(photos1));
 
 beforeEach(() => {
   localStorage.clear();
-  render(<App />);
 });
 
 afterEach(() => {
@@ -22,6 +21,7 @@ afterAll(() => {
 
 describe("App component", () => {
   it("should render", () => {
+    render(<App />);
     waitFor(() => {
       const h1Element = screen.getByRole("heading", { name: "Photo Showcase" });
       expect(h1Element).toBeDefined();
@@ -29,11 +29,13 @@ describe("App component", () => {
   });
 
   it("should display a heading with album number 1", () => {
+    render(<App />);
     const h2Element = screen.getByRole("heading", { name: "Album 1 Photos" });
     expect(h2Element).toBeDefined;
   });
 
   it("should allow the album id to change", async () => {
+    render(<App />);
     const albumIdInput = screen.getByPlaceholderText(
       "Enter album id"
     ) as HTMLInputElement;
@@ -49,6 +51,7 @@ describe("App component", () => {
   });
 
   it("should not allow the album id to change with invalid input", async () => {
+    render(<App />);
     async function verifyAlbumIdHasNotChanged(keyboardInput: string) {
       const photosHeading = screen.getAllByRole("heading", {
         level: 2,
@@ -74,6 +77,7 @@ describe("App component", () => {
   });
 
   it("should update local storage with useEffect", async () => {
+    render(<App />);
     localStorage.setItem(
       "photos",
       JSON.stringify([

--- a/src/__tests__/Photos.test.tsx
+++ b/src/__tests__/Photos.test.tsx
@@ -1,5 +1,6 @@
 // import { describe, it, expect, afterAll } from "bun:test";
 import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import Photos from "../components/Photos";
 import { photos1 } from "../mockPhotoAPIData";
 
@@ -11,6 +12,6 @@ describe("Photos component", () => {
   it("should render", () => {
     render(<Photos photos={photos1} albumId="1" />);
     const h2Element = screen.getByRole("heading", { name: "Album 1 Photos" });
-    expect(h2Element).toBeDefined;
+    expect(h2Element).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- move `render(<App/>)` from `beforeEach` to the individual `App.test.tsx` tests
- replace `toBeDefined` calls with the more conventional `toBeInTheDocument` calls
- replace calls to `innerHTML` with `toHaveTextContent`

